### PR TITLE
Print space after colon separator to match jq output

### DIFF
--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -465,7 +465,7 @@ func newFormatterState(f *Formatter, dst io.Writer) *formatterState {
 			fmt.Fprint(dst, sprintfComma(","))
 		},
 		printColon: func() {
-			fmt.Fprint(dst, sprintfColon(":"))
+			fmt.Fprint(dst, sprintfColon(": "))
 		},
 		printObject: func(t json.Delim) {
 			fmt.Fprint(dst, sprintfObject(t.String()))


### PR DESCRIPTION
After this change what our package prints matches [jq](https://github.com/stedolan/jq) exactly. Thanks!