### PR TITLE
Undo #8 to revert introduced bug, fix #7 differently without breaking other formatting

### DIFF
--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -586,13 +586,6 @@ func (fs *formatterState) format(dst io.Writer, src []byte, terminateWithNewline
 
 	frame := fs.frame()
 
-	// this variable indicates whether the original input
-	// is a JSON object or JSON array. This allows us to
-	// correctly print JSON scalar values such as strings,
-	// numbers, `true`, `false` and `null`.
-
-	inputIsObjectOrArray := false
-
 	for {
 		t, err := dec.Token()
 		if err == io.EOF {
@@ -606,7 +599,6 @@ func (fs *formatterState) format(dst io.Writer, src []byte, terminateWithNewline
 		printComma := frame.inArrayOrObject() && more
 
 		if x, ok := t.(json.Delim); ok {
-			inputIsObjectOrArray = inputIsObjectOrArray && true
 			if x == json.Delim('{') || x == json.Delim('[') {
 				if frame.inObject() {
 					fs.printSpace(" ", false)
@@ -641,7 +633,7 @@ func (fs *formatterState) format(dst io.Writer, src []byte, terminateWithNewline
 			if printIndent {
 				fs.printIndent()
 			}
-			if !frame.inField() && inputIsObjectOrArray {
+			if !frame.inField() {
 				fs.printSpace(" ", false)
 			}
 			err = fs.formatToken(t)

--- a/jsoncolor.go
+++ b/jsoncolor.go
@@ -600,9 +600,7 @@ func (fs *formatterState) format(dst io.Writer, src []byte, terminateWithNewline
 
 		if x, ok := t.(json.Delim); ok {
 			if x == json.Delim('{') || x == json.Delim('[') {
-				if frame.inObject() {
-					fs.printSpace(" ", false)
-				} else {
+				if !frame.inObject() {
 					fs.printIndent()
 				}
 				err = fs.formatToken(x)
@@ -633,12 +631,10 @@ func (fs *formatterState) format(dst io.Writer, src []byte, terminateWithNewline
 			if printIndent {
 				fs.printIndent()
 			}
-			if !frame.inField() {
-				fs.printSpace(" ", false)
-			}
 			err = fs.formatToken(t)
 			if frame.inField() {
 				fs.printColon()
+				fs.printSpace(" ", false)
 			} else {
 				if printComma {
 					fs.printComma()

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -1,0 +1,38 @@
+package jsoncolor
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+)
+
+// https://github.com/nwidger/jsoncolor/issues/7
+func Test_Issue7(t *testing.T) {
+	v := struct {
+		Null   *string `json:"null"`
+		True   bool    `json:"true"`
+		False  bool    `json:"false"`
+		Number int     `json:"number"`
+		String string  `json:"string"`
+	}{
+		True:   true,
+		False:  false,
+		Number: 123,
+		String: "string",
+	}
+	goJsonBuf, err := json.MarshalIndent(v.String, "", " ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	jsonColorBuf, err := MarshalIndent(v.String, "", " ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	goJsonStr := string(goJsonBuf)
+	jsonColorStr := string(jsonColorBuf)
+
+	if goJsonStr != jsonColorStr {
+		t.Errorf("jsoncolor output %q does not match go's json output %s", jsonColorStr, goJsonStr)
+	}
+}

--- a/jsoncolor_test.go
+++ b/jsoncolor_test.go
@@ -2,6 +2,7 @@ package jsoncolor
 
 import (
 	"encoding/json"
+	"github.com/fatih/color"
 	"log"
 	"testing"
 )
@@ -34,5 +35,32 @@ func Test_Issue7(t *testing.T) {
 
 	if goJsonStr != jsonColorStr {
 		t.Errorf("jsoncolor output %q does not match go's json output %s", jsonColorStr, goJsonStr)
+	}
+}
+
+func Test_MatchesGoForScalarFieldAndForListWithElements(t *testing.T) {
+	color.NoColor = true // color not important to this test
+
+	v := struct {
+		Number int   `json:"number"`
+		List   []int `json:"list"`
+	}{
+		Number: 123,
+		List:   []int{1, 2, 3},
+	}
+	goJsonBuf, err := json.MarshalIndent(v, "", " ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	jsonColorBuf, err := MarshalIndent(v, "", " ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	goJsonStr := string(goJsonBuf)
+	jsonColorStr := string(jsonColorBuf)
+
+	if goJsonStr != jsonColorStr {
+		t.Errorf("jsoncolor output does not match go's json output. jsoncolor and go respectively:\n%q\n%q\n", jsonColorStr, goJsonStr)
 	}
 }


### PR DESCRIPTION
See my comments on #9 . The fix in #8 doesn't work as intended and breaks formatting for the below case:

Broken (current master version):

```json
{
  "foo":"bar", << notice missing space
  "quz": []    << notice *correct* space
}
```

Fixed with this PR:

```json
{
  "foo": "bar",
  "quz": []
}
```

I also include a couple of basic test cases demonstrating the fix to #7 and #9.

The individual commits in this PR contain some commentary and should probably not be squashed.